### PR TITLE
Fix: invalid url

### DIFF
--- a/kkiapay/core.py
+++ b/kkiapay/core.py
@@ -2,11 +2,6 @@ import json
 import requests
 from collections import namedtuple
 
-try:
-    from types import SimpleNamespace as Namespace
-except ImportError:
-    from argparse import Namespace
-
 
 class Kkiapay:
 


### PR DESCRIPTION
Après le premier appel à l'une des fonctions **verify_transaction**, **refund_transaction** et **setup_payout**, tout ce passe bien. Mais ensuite, les appels suivants renvoient une erreur. En effet, la valeur de **self_url** est incorrect. 
C'est le but de ce fix. 